### PR TITLE
Update JUnit to latest 4.x minor version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
to get rid of a tmp. folder vulnerability (CVE-2020-15250).